### PR TITLE
changes required for linear_interpolation function

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -505,6 +505,7 @@ add("is_nan", INT_T, DOUBLE_T);
 add_binary("lbeta");
 add_binary("lchoose");
 add_unary_vectorized("lgamma");
+add("linear_interpolation", vector_types[1], vector_types[1], vector_types[1], vector_types[1]);
 add("lkj_corr_cholesky_log", DOUBLE_T, MATRIX_T, DOUBLE_T);
 add("lkj_corr_cholesky_lpdf", DOUBLE_T, MATRIX_T, DOUBLE_T);
 add("lkj_corr_cholesky_rng", MATRIX_T, INT_T, DOUBLE_T);

--- a/src/test/test-models/good/function-signatures/math/matrix/linear_interpolation.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/linear_interpolation.stan
@@ -1,0 +1,34 @@
+data {
+  int d_int;
+  int d2_int;
+  int d3_int;
+  real d_real_array[d_int];
+  real d2_real_array[d2_int];
+  real d3_real_array[d3_int];
+}
+transformed data {
+  real transformed_data_real_array[d_int];
+
+  transformed_data_real_array <- linear_interpolation(d_real_array, d2_real_array, d3_real_array);
+}
+parameters {
+  real p_real_array[d_int];
+  real p2_real_array[d2_int];
+  real p3_real_array[d3_int];
+  real y_p;
+}
+transformed parameters {
+  real transformed_param_real_array[d_int];
+
+  transformed_param_real_array <- linear_interpolation(d_real_array, d2_real_array, d3_real_array);
+  transformed_param_real_array <- linear_interpolation(d_real_array, d2_real_array, p3_real_array);
+  transformed_param_real_array <- linear_interpolation(d_real_array, p2_real_array, d3_real_array);
+  transformed_param_real_array <- linear_interpolation(d_real_array, p2_real_array, p3_real_array);
+  transformed_param_real_array <- linear_interpolation(p_real_array, d2_real_array, d3_real_array);
+  transformed_param_real_array <- linear_interpolation(p_real_array, d2_real_array, p3_real_array);
+  transformed_param_real_array <- linear_interpolation(p_real_array, p2_real_array, d3_real_array);
+  transformed_param_real_array <- linear_interpolation(p_real_array, p2_real_array, p3_real_array);
+}
+model {  
+  y_p ~ normal(0,1);
+}

--- a/src/test/unit/lang/parser/matrix_functions_test.cpp
+++ b/src/test/unit/lang/parser/matrix_functions_test.cpp
@@ -135,6 +135,10 @@ TEST(lang_parser, inverse_spd_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/inverse_spd");
 }
 
+TEST(lang_parser, linear_interpolation_matrix_function_signatures) {
+  test_parsable("function-signatures/math/matrix/linear_interpolation");
+}
+
 TEST(lang_parser, log_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/log");
 }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary
The proposed changes add linear_interpolation to the Stan function signatures and provide code for testing the function signatures

#### Intended Effect
Provide a Stan language function for piecewise linear interpolation.

#### How to Verify
Run unit tests. In addition a working example called testInterp2.rmd is provided in the example-models repo.

#### Side Effects

#### Documentation
linear_interpolation is documented in the Torsten Users Manual

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
